### PR TITLE
Hacer querys para renovación de los contratos

### DIFF
--- a/server/controllers/contratoController.js
+++ b/server/controllers/contratoController.js
@@ -9,8 +9,21 @@ const getOpcionesContratoProveedor = (request, response) => {
   });
 };
 
-
+const postRenovarContrato = (request, response) => {
+  console.log(request.body);
+  const text =
+    "INSERT INTO ydm_renueva(id_renueva, id_contrato_renueva, fecha_renueva) VALUES (DEFAULT, $1, current_date) RETURNING *";
+  const values = [request.body.id_contrato];
+  pool.query(text, values, (error, results) => {
+    if (error) {
+      console.log("ERROR DE RENOVACIÓN DE CONTRATO: " + error);
+      throw error;
+    }
+    response.status(201).send(results.rows);
+  });
+};
 
 module.exports = {
   getOpcionesContratoProveedor,
+  postRenovarContrato,
 };

--- a/server/controllers/proveedorController.js
+++ b/server/controllers/proveedorController.js
@@ -12,14 +12,17 @@ const getProveedores = (request, response) => {
 const getProveedoresPotenciales = (request, response) => {
   let values = [request.body.id_productor];
   const query =
-    "SELECT DISTINCT id_proveedor, nombre_proveedor, web_proveedor, email_proveedor, nombre_pais\
-  FROM ydm_pi_pdt_env, ydm_alt_envio, ydm_proveedor, ydm_pais, ydm_miembro_ifra\
-  WHERE id_productor_pi_pdt_env = $1\
-    AND id_pais_pi_pdt_env = id_pais_alt_envio\
-    AND id_pais_pi_pdt_env = id_pais\
-    AND id_proveedor_alt_envio = id_proveedor\
-    AND id_proveedor = id_proveedor_miembro_ifra\
-    AND fecha_exclusion_miembro_ifra is null";
+    "SELECT DISTINCT id_proveedor, nombre_proveedor, web_proveedor, email_proveedor, nombre_pais as pais_envio\
+    FROM ydm_pi_pdt_env, ydm_alt_envio, ydm_proveedor, ydm_pais, ydm_miembro_ifra\
+    WHERE id_productor_pi_pdt_env = $1\
+      AND id_pais_pi_pdt_env = id_pais_alt_envio AND id_pais_pi_pdt_env = id_pais\
+      AND id_proveedor_alt_envio = id_proveedor AND id_proveedor = id_proveedor_miembro_ifra\
+    AND id_proveedor NOT IN (\
+      SELECT DISTINCT id_proveedor_contrato from ydm_contrato, ydm_renueva\
+      WHERE id_productor_contrato = $1\
+      AND ((fecha_emision_contrato + 365 > current_date AND fecha_cancela_contrato is null)\
+      OR (id_contrato IN (SELECT id_contrato_renueva from ydm_renueva where fecha_renueva + 365 > current_date)))\
+      ) AND fecha_exclusion_miembro_ifra is null";
   pool.query(query, values, (error, results) => {
     if (error) {
       throw error;
@@ -31,18 +34,26 @@ const getProveedoresPotenciales = (request, response) => {
 const getProveedoresPorRenovar = (request, response) => {
   let values = [request.body.id_productor];
   const query =
-    "SELECT id_proveedor, nombre_proveedor, web_proveedor, email_proveedor, id_contrato, fecha_emision_contrato, (\
-			SELECT fecha_renueva FROM ydm_renueva r\
-			WHERE fecha_renueva + 365 BETWEEN current_date AND current_date + 30\
-        AND id_contrato_renueva = cont.id_contrato ORDER BY fecha_renueva desc LIMIT 1 ), nombre_pais\
-    FROM ydm_proveedor prov, ydm_contrato cont, ydm_productor, ydm_pais WHERE id_productor = $1\
-    AND id_productor = id_productor_contrato AND id_proveedor = id_proveedor_contrato\
-    AND id_pais = id_pais_proveedor AND fecha_cancela_contrato is null\
-    AND	(fecha_emision_contrato + 365 BETWEEN current_date AND current_date + 30\
-      OR (SELECT fecha_renueva FROM ydm_renueva r\
-        WHERE fecha_renueva + 365 BETWEEN current_date AND current_date + 30\
-        AND id_contrato_renueva = cont.id_contrato ORDER BY fecha_renueva desc LIMIT 1 ) + 365\
-        BETWEEN current_date AND current_date + 30)";
+    "SELECT id_proveedor, nombre_proveedor, web_proveedor, email_proveedor, nombre_pais as pais_proveedor, id_contrato, fecha_emision_contrato, (\
+			SELECT fecha_renueva FROM ydm_renueva\
+      WHERE id_contrato_renueva = cont.id_contrato ORDER BY fecha_renueva desc LIMIT 1)\
+    FROM ydm_proveedor prov, ydm_contrato cont, ydm_productor, ydm_pais\
+    WHERE id_productor = $1 AND id_productor = id_productor_contrato AND id_proveedor = id_proveedor_contrato\
+    AND id_pais = id_pais_proveedor AND fecha_cancela_contrato is null AND	fecha_emision_contrato + 365 BETWEEN current_date AND current_date + 30\
+	  AND (SELECT fecha_renueva FROM ydm_renueva\
+		    WHERE fecha_renueva BETWEEN current_date - 365 AND current_date AND id_contrato_renueva = cont.id_contrato\
+    ORDER BY fecha_renueva desc LIMIT 1) IS null\
+ UNION \
+SELECT id_proveedor, nombre_proveedor, web_proveedor, email_proveedor, nombre_pais as pais_proveedor, id_contrato, fecha_emision_contrato, (\
+			SELECT fecha_renueva FROM ydm_renueva\
+			WHERE id_contrato_renueva = cont.id_contrato ORDER BY fecha_renueva desc LIMIT 1)\
+    FROM ydm_proveedor prov, ydm_contrato cont, ydm_productor, ydm_pais\
+    WHERE id_productor = $1 AND id_productor = id_productor_contrato AND id_proveedor = id_proveedor_contrato AND id_pais = id_pais_proveedor\
+      AND fecha_cancela_contrato is null AND\
+        (SELECT fecha_renueva FROM ydm_renueva ren\
+          WHERE fecha_renueva + 365 BETWEEN current_date AND current_date + 30\
+            AND id_contrato_renueva = cont.id_contrato\
+          ORDER BY fecha_renueva desc LIMIT 1) + 365 BETWEEN current_date AND current_date + 30";
   pool.query(query, values, (error, results) => {
     if (error) {
       throw error;

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,24 +1,27 @@
 const express = require("express");
 const router = express.Router();
 const proveedorController = require("./controllers/proveedorController");
-//const productorController = require("./controllers/productorController")
 const productorController = require("./controllers/productorController");
+const contratoController = require("./controllers/contratoController");
 
 router.get("/ping", (req, res) => {
   return res.send("pong");
 }); //TEST
 
-
 router.post("/read/proveedores", proveedorController.getProveedores); //OBTENER TODOS LOS PROVEEDORES
 router.post(
+  //OBTENER TODOS LOS PROVEEDORES POTENCIALES
   "/read/proveedores-potenciales",
   proveedorController.getProveedoresPotenciales
-); //OBTENER TODOS LOS PROVEEDORES POTENCIALES
+);
 router.post(
+  //OBTENER PROVEEDORES POR RENOVAR
   "/read/proveedores-por-renovar",
   proveedorController.getProveedoresPorRenovar
-); //OBTENER PROVEEDORES POR RENOVAR
+);
 
-router.get("/read/productores", productorController.getProductores);//OBTENER TODOS LOS PRODUCTORES
+router.get("/read/productores", productorController.getProductores); //OBTENER TODOS LOS PRODUCTORES
+
+router.post("/create/renovacion", contratoController.postRenovarContrato); //RENOVAR CONTRATO
 
 module.exports = router;


### PR DESCRIPTION
Aparte de hacer la renovación de contratos también se corrigieron los
querys de proveedores por renovar y proveedores potenciales.